### PR TITLE
Fallback

### DIFF
--- a/src/org/aion/abigenerator/ABICompiler.java
+++ b/src/org/aion/abigenerator/ABICompiler.java
@@ -16,6 +16,7 @@ import java.util.jar.Manifest;
 public class ABICompiler {
 
     private static final int MAX_CLASS_BYTES = 1024 * 1024;
+    private static final float VERSION_NUMBER = 0.0F;
 
     private String mainClassName;
     private byte[] mainClassBytes;
@@ -43,6 +44,7 @@ public class ABICompiler {
         compiler.compile(fileInputStream);
 
         List<String> callables = compiler.getCallables();
+        System.out.println(VERSION_NUMBER);
         for (String s : callables) System.out.println(s);
 
         try {
@@ -154,5 +156,9 @@ public class ABICompiler {
 
     public Map<String, byte[]> getClassMap() {
         return outputClassMap;
+    }
+
+    public static float getVersionNumber() {
+        return VERSION_NUMBER;
     }
 }

--- a/src/org/aion/abigenerator/ABICompilerClassVisitor.java
+++ b/src/org/aion/abigenerator/ABICompilerClassVisitor.java
@@ -8,37 +8,47 @@ import java.util.List;
 import static org.objectweb.asm.Opcodes.*;
 
 public class ABICompilerClassVisitor extends ClassVisitor {
-    private boolean isMain;
-    private boolean hasMain = false;
+    private boolean isMainClass;
+    private boolean hasMainMethod = false;
     private String className;
+    private String fallbackMethodName = "";
     private List<ABICompilerMethodVisitor> methodVisitors = new ArrayList<>();
+    private List<ABICompilerMethodVisitor> callableMethodVisitors = new ArrayList<>();
+    private List<String> signatures = new ArrayList<>();
 
     public ABICompilerClassVisitor(ClassWriter cw) {
         super(Opcodes.ASM6, cw);
     }
 
     public void setMain() {
-        isMain = true;
+        isMainClass = true;
     }
 
     public List<String> getCallables() {
-        List<String> signatures = new ArrayList<>();
-        for (ABICompilerMethodVisitor mv : methodVisitors) {
-            if (mv.isCallable()) {
-                signatures.add(this.className + ": " + mv.getSignature());
-            }
-        }
         return signatures;
     }
 
     public List<ABICompilerMethodVisitor> getCallableMethodVisitors() {
-        List<ABICompilerMethodVisitor> callableMethodVisitors = new ArrayList<>();
+        return callableMethodVisitors;
+    }
+
+    private void postProcess() {
+        boolean foundFallback = false;
         for (ABICompilerMethodVisitor mv : methodVisitors) {
             if (mv.isCallable()) {
+                signatures.add(this.className + ": " + mv.getSignature());
                 callableMethodVisitors.add(mv);
             }
+            if (mv.isFallback()) {
+                if(!foundFallback) {
+                    fallbackMethodName = mv.getMethodName();
+                    foundFallback = true;
+                }
+                else {
+                    // fail
+                }
+            }
         }
-        return callableMethodVisitors;
     }
 
     @Override
@@ -51,11 +61,11 @@ public class ABICompilerClassVisitor extends ClassVisitor {
     public MethodVisitor visitMethod(
             int access, String name, String descriptor, String signature, String[] exceptions) {
         if (name.equals("main") && ((access & Opcodes.ACC_PUBLIC) != 0)) {
-            hasMain = true;
+            hasMainMethod = true;
         }
         ABICompilerMethodVisitor mv = new ABICompilerMethodVisitor(access, name, descriptor,
                 super.visitMethod(access, name, descriptor, signature, exceptions));
-        if (isMain) {
+        if (isMainClass) {
             methodVisitors.add(mv);
         }
         return mv;
@@ -63,78 +73,96 @@ public class ABICompilerClassVisitor extends ClassVisitor {
 
     @Override
     public void visitEnd() {
-        if (isMain && !hasMain) {
-
-            // write function signature
-            MethodVisitor methodVisitor =
-                    super.visitMethod(ACC_PUBLIC | ACC_STATIC, "main", "()[B", null, null);
-            methodVisitor.visitCode();
-
-            // set inputBytes = BlockchainRuntime.getData();
-            methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/BlockchainRuntime", "getData", "()[B", false);
-            methodVisitor.visitVarInsn(ASTORE, 0);
-            Label label1 = new Label();
-            methodVisitor.visitLabel(label1);
-
-            // set methodName = ABIDecoder.decodeMethodName(inputBytes);
-            methodVisitor.visitVarInsn(ALOAD, 0);
-            methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/ABIDecoder", "decodeMethodName", "([B)Ljava/lang/String;", false);
-            methodVisitor.visitVarInsn(ASTORE, 1);
-            Label label2 = new Label();
-            methodVisitor.visitLabel(label2);
-
-            // set argValues = ABIDecoder.decodeArguments(BlockchainRuntime.getData());
-            methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/BlockchainRuntime", "getData", "()[B", false);
-            methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/ABIDecoder", "decodeArguments", "([B)[Ljava/lang/Object;", false);
-            methodVisitor.visitVarInsn(ASTORE, 2);
-
-            Label latestLabel = new Label();
-            Label firstLabel = latestLabel;
-
-            for (ABICompilerMethodVisitor callableMethod : this.getCallableMethodVisitors()) {
-
-                // latestLabel is the goto label of the preceding if condition
-                methodVisitor.visitLabel(latestLabel);
-                methodVisitor.visitVarInsn(ALOAD, 1);
-                methodVisitor.visitLdcInsn(callableMethod.getMethodName());
-                methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
-                latestLabel = new Label();
-                methodVisitor.visitJumpInsn(IFEQ, latestLabel);
-
-                // load the various arguments as indicated by the function signature, casting them as needed
-                Type[] argTypes = Type.getArgumentTypes(callableMethod.getDescriptor());
-
-                for (int i = 0; i < argTypes.length; i++) {
-                    methodVisitor.visitVarInsn(ALOAD, 2);
-                    methodVisitor.visitIntInsn(BIPUSH, i);
-                    methodVisitor.visitInsn(AALOAD);
-                    castArgumentType(methodVisitor, argTypes[i]);
-                }
-
-                // return ABIEncoder.encodeOneObject(<methodName>(<arguments>));
-                methodVisitor.visitMethodInsn(INVOKESTATIC, className, callableMethod.getMethodName(), callableMethod.getDescriptor(), false);
-                castReturnType(methodVisitor, Type.getReturnType(callableMethod.getDescriptor()));
-                methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/ABIEncoder", "encodeOneObject", "(Ljava/lang/Object;)[B", false);
-                methodVisitor.visitInsn(ARETURN);
-            }
-
-            // this latestLabel is the catch-all else, we just return null
-            methodVisitor.visitLabel(latestLabel);
-            methodVisitor.visitFrame(Opcodes.F_APPEND, 3, new Object[]{"[B", "java/lang/String", "[Ljava/lang/Object;"}, 0, null);
-            methodVisitor.visitInsn(ACONST_NULL);
-            methodVisitor.visitInsn(ARETURN);
-            Label lastLabel = new Label();
-            methodVisitor.visitLabel(lastLabel);
-            methodVisitor.visitLocalVariable("inputBytes", "[B", null, label1, lastLabel, 0);
-            methodVisitor.visitLocalVariable("methodName", "Ljava/lang/String;", null, label2, lastLabel, 1);
-            methodVisitor.visitLocalVariable("argValues", "[Ljava/lang/Object;", null, firstLabel, lastLabel, 2);
-            methodVisitor.visitMaxs(2, 3);
-            methodVisitor.visitEnd();
+        postProcess();
+        if (isMainClass && fallbackMethodName.isEmpty()) {
+            addFallbackMethod();
         }
-        if (!isMain && hasMain) {
+        if (isMainClass && !hasMainMethod) {
+            addMainMethod();
+        }
+        if (!isMainClass && hasMainMethod) {
             throw new IllegalMainMethodsException("Non-main class can't have main() method!");
         }
         super.visitEnd();
+    }
+
+    private void addFallbackMethod() {
+        fallbackMethodName = "fallback";
+        // write function signature
+        MethodVisitor methodVisitor =
+            super.visitMethod(ACC_PRIVATE | ACC_STATIC, "fallback", "()V", null, null);
+        methodVisitor.visitCode();
+        methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/BlockchainRuntime", "revert", "()V", false);
+        methodVisitor.visitInsn(RETURN);
+    }
+
+    private void addMainMethod() {
+        // write function signature
+        MethodVisitor methodVisitor =
+            super.visitMethod(ACC_PUBLIC | ACC_STATIC, "main", "()[B", null, null);
+        methodVisitor.visitCode();
+
+        // set inputBytes = BlockchainRuntime.getData();
+        methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/BlockchainRuntime", "getData", "()[B", false);
+        methodVisitor.visitVarInsn(ASTORE, 0);
+        Label label1 = new Label();
+        methodVisitor.visitLabel(label1);
+
+        // set methodName = ABIDecoder.decodeMethodName(inputBytes);
+        methodVisitor.visitVarInsn(ALOAD, 0);
+        methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/ABIDecoder", "decodeMethodName", "([B)Ljava/lang/String;", false);
+        methodVisitor.visitVarInsn(ASTORE, 1);
+        Label label2 = new Label();
+        methodVisitor.visitLabel(label2);
+
+        // set argValues = ABIDecoder.decodeArguments(BlockchainRuntime.getData());
+        methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/BlockchainRuntime", "getData", "()[B", false);
+        methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/ABIDecoder", "decodeArguments", "([B)[Ljava/lang/Object;", false);
+        methodVisitor.visitVarInsn(ASTORE, 2);
+
+        Label latestLabel = new Label();
+        Label firstLabel = latestLabel;
+
+        for (ABICompilerMethodVisitor callableMethod : this.getCallableMethodVisitors()) {
+
+            // latestLabel is the goto label of the preceding if condition
+            methodVisitor.visitLabel(latestLabel);
+            methodVisitor.visitVarInsn(ALOAD, 1);
+            methodVisitor.visitLdcInsn(callableMethod.getMethodName());
+            methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
+            latestLabel = new Label();
+            methodVisitor.visitJumpInsn(IFEQ, latestLabel);
+
+            // load the various arguments as indicated by the function signature, casting them as needed
+            Type[] argTypes = Type.getArgumentTypes(callableMethod.getDescriptor());
+
+            for (int i = 0; i < argTypes.length; i++) {
+                methodVisitor.visitVarInsn(ALOAD, 2);
+                methodVisitor.visitIntInsn(BIPUSH, i);
+                methodVisitor.visitInsn(AALOAD);
+                castArgumentType(methodVisitor, argTypes[i]);
+            }
+
+            // return ABIEncoder.encodeOneObject(<methodName>(<arguments>));
+            methodVisitor.visitMethodInsn(INVOKESTATIC, className, callableMethod.getMethodName(), callableMethod.getDescriptor(), false);
+            castReturnType(methodVisitor, Type.getReturnType(callableMethod.getDescriptor()));
+            methodVisitor.visitMethodInsn(INVOKESTATIC, "org/aion/avm/api/ABIEncoder", "encodeOneObject", "(Ljava/lang/Object;)[B", false);
+            methodVisitor.visitInsn(ARETURN);
+        }
+
+        // this latestLabel is the catch-all else, we just return null
+        methodVisitor.visitLabel(latestLabel);
+        methodVisitor.visitFrame(Opcodes.F_APPEND, 3, new Object[]{"[B", "java/lang/String", "[Ljava/lang/Object;"}, 0, null);
+        methodVisitor.visitMethodInsn(INVOKESTATIC, className, fallbackMethodName, "()V", false);
+        methodVisitor.visitInsn(ACONST_NULL);
+        methodVisitor.visitInsn(ARETURN);
+        Label lastLabel = new Label();
+        methodVisitor.visitLabel(lastLabel);
+        methodVisitor.visitLocalVariable("inputBytes", "[B", null, label1, lastLabel, 0);
+        methodVisitor.visitLocalVariable("methodName", "Ljava/lang/String;", null, label2, lastLabel, 1);
+        methodVisitor.visitLocalVariable("argValues", "[Ljava/lang/Object;", null, firstLabel, lastLabel, 2);
+        methodVisitor.visitMaxs(2, 3);
+        methodVisitor.visitEnd();
     }
 
     private void castArgumentType(MethodVisitor mv, Type t) {
@@ -173,7 +201,6 @@ public class ABICompilerClassVisitor extends ClassVisitor {
                 break;
             case Type.OBJECT:
             case Type.ARRAY:
-                System.out.println(t.getInternalName());
                 mv.visitTypeInsn(CHECKCAST, t.getInternalName());
                 break;
         }

--- a/src/org/aion/abigenerator/ABICompilerMethodVisitor.java
+++ b/src/org/aion/abigenerator/ABICompilerMethodVisitor.java
@@ -57,11 +57,14 @@ public class ABICompilerMethodVisitor extends MethodVisitor {
             isCallable = true;
             return null;
         } else if (Type.getType(descriptor).getClassName().equals(Fallback.class.getName())) {
-            if (Type.getReturnType(descriptor) != Type.VOID_TYPE) {
+            if (!isStatic) {
+                throw new AnnotationException("Fallback function must be static", methodName);
+            }
+            if (Type.getReturnType(methodDescriptor) != Type.VOID_TYPE) {
                 throw new AnnotationException(
                     "Function annotated @Fallback must have void return type", methodName);
             }
-            if (Type.getArgumentTypes(descriptor).length != 0) {
+            if (Type.getArgumentTypes(methodDescriptor).length != 0) {
                 throw new AnnotationException(
                     "Function annotated @Fallback cannot take arguments", methodName);
             }

--- a/src/org/aion/abigenerator/AnnotationException.java
+++ b/src/org/aion/abigenerator/AnnotationException.java
@@ -1,0 +1,7 @@
+package org.aion.abigenerator;
+
+public class AnnotationException extends RuntimeException {
+    public AnnotationException(String exceptionString, String methodName) {
+        super("Exception in method " + methodName + ": " + exceptionString);
+    }
+}

--- a/src/org/aion/abigenerator/Fallback.java
+++ b/src/org/aion/abigenerator/Fallback.java
@@ -1,0 +1,11 @@
+package org.aion.abigenerator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD})
+public @interface Fallback {
+}

--- a/test/IntegTest.java
+++ b/test/IntegTest.java
@@ -158,6 +158,9 @@ public class IntegTest {
         int newVal = (Integer) callStatic(dapp, "getValue");
 
         assertEquals(oldVal + 10, newVal);
+        callStatic(dapp, "", 7);
 
+        newVal = (Integer) callStatic(dapp, "getValue");
+        assertEquals(oldVal + 20, newVal);
     }
 }

--- a/test/IntegTest.java
+++ b/test/IntegTest.java
@@ -1,3 +1,4 @@
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -69,7 +70,11 @@ public class IntegTest {
                         ENERGY_PRICE)
                         .getTransactionResult();
         assertEquals(AvmTransactionResult.Code.SUCCESS, result.getResultCode());
-        return ABIDecoder.decodeOneObject(result.getReturnData());
+        if (result.getReturnData() != null) {
+            return ABIDecoder.decodeOneObject(result.getReturnData());
+        } else {
+            return null;
+        }
     }
 
     @Test
@@ -134,9 +139,25 @@ public class IntegTest {
         assertEquals("alphabetfalse123", ret);
 
         int[] intArray = (int[]) callStatic(dapp, "returnArrayOfInt", 1, 2, 3);
-        assertTrue(Arrays.equals(new int[]{1, 2, 3}, intArray));
+        assertArrayEquals(new int[]{1, 2, 3}, intArray);
 
         String[] strArray = (String[]) callStatic(dapp, "returnArrayOfString", "hello", "world", "!");
-        assertTrue(Arrays.equals(new String[]{"hello", "world", "!"}, strArray));
+        assertArrayEquals(new String[]{"hello", "world", "!"}, strArray);
+    }
+
+
+    @Test
+    public void testFallback() {
+        byte[] jar =
+            JarBuilder.buildJarForMainAndClasses(SimpleDAppNoMain.class);
+        compiler.compile(new ByteArrayInputStream(jar));
+        Address dapp = installTestDApp();
+
+        int oldVal = (Integer) callStatic(dapp, "getValue");
+        callStatic(dapp, "garbageMethod", 7);
+        int newVal = (Integer) callStatic(dapp, "getValue");
+
+        assertEquals(oldVal + 10, newVal);
+
     }
 }

--- a/test/MainTest.java
+++ b/test/MainTest.java
@@ -24,8 +24,10 @@ public class MainTest {
     @Test
     public void testMain() {
 
-        ABICompiler.main(new String[]{System.getProperty("user.dir") + "/test/dapp.jar"});
-        assertEquals("ChattyCalculator: public static java.lang.String amIGreater(int, int)\n",
+        ABICompiler.main(new String[] {System.getProperty("user.dir") + "/test/dapp.jar"});
+        assertEquals(
+                ABICompiler.getVersionNumber()
+                        + "\nChattyCalculator: public static java.lang.String amIGreater(int, int)\n",
                 outContent.toString());
     }
 }

--- a/test/SimpleDAppNoMain.java
+++ b/test/SimpleDAppNoMain.java
@@ -1,6 +1,9 @@
 import org.aion.abigenerator.Callable;
+import org.aion.abigenerator.Fallback;
 
 public class SimpleDAppNoMain {
+
+    static private int a = 0;
 
     @Callable()
     public static boolean test1(boolean b) {
@@ -12,9 +15,19 @@ public class SimpleDAppNoMain {
         return true;
     }
 
+    @Callable()
+    public static int getValue() {
+        return a;
+    }
+
     @Deprecated
     public static boolean test3(int i, String s, long[] l) {
         return true;
+    }
+
+    @Fallback
+    private static void fallbackIncrease10() {
+        a += 10;
     }
 }
 


### PR DESCRIPTION
This PR lets users define a default fallback function along the lines of Solidity's fallback function: https://solidity.readthedocs.io/en/v0.4.24/contracts.html#fallback-function.

If such a function is specified, it must be `static` and `void`, it must take no arguments, and the generated `main` method invokes it if the `RuntimeData` is empty, or has an unfound method name.

As an auxiliary change, this PR also adds a `VERSION_NUMBER` of 0.0 for the current generated ABI.